### PR TITLE
Changing bindings to widget._on to allow cleanup on destroy.

### DIFF
--- a/js/jquery.smoothDivScroll-1.3.js
+++ b/js/jquery.smoothDivScroll-1.3.js
@@ -251,8 +251,8 @@
 			});
 
 			// mouseup anywhere (stop boosting the scrolling speed)
-			self._on($('body'), {
-				'mouseup': function() {
+			self._on($("body"), {
+				"mouseup": function() {
 					el.data("speedBooster", 1);	
 				}
 			});
@@ -366,7 +366,7 @@
 			SET UP EVENT FOR RESIZING THE BROWSER WINDOW
 			*****************************************/
 			self._on(window, {
-				'resize': function() {
+				"resize": function() {
 					self._showHideHotSpots();
 					self._trigger("windowResized");
 				}


### PR DESCRIPTION
We were running an AB Test where we had to destroy the widget after it had been initialized, most of the bindings were cleaned up on _destroy, except for the ones set on body and window, so there were errors being thrown every time each time one of those events was being triggered.

Also, if you do all of your bindings with _on you don't need to clean them up on destroy :) http://api.jqueryui.com/jQuery.widget/#method-_on
