### PR TITLE
Fixed typing mistake in hideHotSpotBackgrounds() functions

### DIFF
--- a/js/source/jquery.smoothDivScroll-1.3.js
+++ b/js/source/jquery.smoothDivScroll-1.3.js
@@ -517,7 +517,7 @@
 
 		},
 		hideHotSpotBackgrounds: function (fadeSpeed) {
-			var el = this.element, o = this.option;
+			var el = this.element, o = this.options;
 
 			// Fade out the hotspot backgrounds
 			if (fadeSpeed !== undefined) {


### PR DESCRIPTION
Fixed typing mistake in hideHotSpotBackgrounds() functions
var el = this.element, o = this.option;
should be
var el = this.element, o = this.options;
