### PR TITLE
Add option to bind to more events other than window.load 

### DIFF
--- a/js/source/jquery.smoothDivScroll-1.3.js
+++ b/js/source/jquery.smoothDivScroll-1.3.js
@@ -398,8 +398,17 @@
 			// setting of the hotspot backgrounds is started here as well for the same reason. 
 			// If the auto scrolling is not started in $(window).load, it won't start because it 
 			// will interpret the scrollable areas as too short.
-			$(window).load(function () {
+			$(window).load($.proxy(self._widthKnown, self));
+			if(o.additionalLoadEvents) {
+				//format: [{selector, event}]
+				$.each(o.additionalLoadEvents, function(i, n) {
+					$(n.selector).on(n.event, $.proxy(self._widthKnown, self));
+				});
+			}
 
+		},
+		_widthKnown: function() {
+				var o = this.options, self = this, el = this.element;
 				// If scroller is not hidden, recalculate the scrollable area
 				if (!(o.hiddenOnStart)) {
 					self.recalculateScrollableArea();
@@ -445,8 +454,6 @@
 				self._showHideHotSpots();
 
 				self._trigger("setupComplete");
-
-			});
 
 		},
 		/**********************************************************


### PR DESCRIPTION
Some apps do not fire window.load when smoothdivscroll should finish initializing (eg. rails apps with wiselinks or other ajaxy things).  Provide an option to indicate what additional events to bind to when the widths are known.

My first pull request so be gentle if I am not following some sort of unspoken protocol ;)
