### PR TITLE
Added filterTarget option to handle clickable events

### DIFF
--- a/js/source/jquery.smoothDivScroll-1.3.js
+++ b/js/source/jquery.smoothDivScroll-1.3.js
@@ -79,7 +79,10 @@
 
 			// Easing for when the scrollToElement method is used
 			scrollToAnimationDuration: 1000, // Milliseconds
-			scrollToEasingFunction: "easeOutQuart" // String
+			scrollToEasingFunction: "easeOutQuart", // String
+			
+			// Filter target (used by jquery.kinetic to handle clickable events) 
+            		filterTarget: false // Boolean
 		},
 		_create: function () {
 			var self = this, o = this.options, el = this.element;
@@ -192,7 +195,8 @@
 
 						// Callback
 						self._trigger("touchStopped");
-					}
+					},
+					filterTarget: o.filterTarget
 				});
 			}
 


### PR DESCRIPTION
Added filterTarget option to be able to filter clickable events in jquery.kinetic.
This makes it possible to use links, inputs or selects inside the scrolling div.

Usage:
`$("div#makeMeScrollable").smoothDivScroll({
    filterTarget: function (target, e) {
        if (!/down|start/.test(e.type)) {
            return !(/area|a|input|select/i.test(target.tagName));
        }
    }
});`